### PR TITLE
install python3 alpine packages and update docker version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,16 +2,16 @@ version: 2.1
 jobs:
   build:
     docker:
-      - image: docker:18.09-git
+      - image: docker:19.03-git
     steps:
       - checkout
       - setup_remote_docker:
-          version: 18.09.3
+          version: 19.03.12
       - run:
           name: Install dependencies
           command: |
             apk add --no-cache \
-              python-dev py-pip bash pigz build-base libffi-dev openssl-dev
+              python3-dev py3-pip bash pigz build-base libffi-dev openssl-dev
             pip install \
               docker-compose awscli
       - run:
@@ -26,16 +26,16 @@ jobs:
             - "*"
   build-periodically:
     docker:
-      - image: docker:18.09-git
+      - image: docker:19.03-git
     steps:
       - checkout
       - setup_remote_docker:
-          version: 18.09.3
+          version: 19.03.12
       - run:
           name: Install dependencies
           command: |
             apk add --no-cache \
-              python-dev py-pip bash pigz build-base libffi-dev openssl-dev
+              python3-dev py3-pip bash pigz build-base libffi-dev openssl-dev
             pip install \
               docker-compose awscli
       - run:


### PR DESCRIPTION
Our circleCI jobs utilize the docker:18.09-git docker images (based on Alpine Linux) to perform builds and unit tests. During setup of these docker containers, we install python and other dependencies using `apk`, the Alpine Linux package manager. Recent updates to the Alpine package repository have decommisioned python2:

```
/ # apk add --no-cache python-dev py-pip bash pigz build-base libffi-dev openssl-dev
fetch http://dl-cdn.alpinelinux.org/alpine/v3.10/main/x86_64/APKINDEX.tar.gz
WARNING: Ignoring http://dl-cdn.alpinelinux.org/alpine/v3.10/main/x86_64/APKINDEX.tar.gz: remote server returned error (try 'apk update')
fetch http://dl-cdn.alpinelinux.org/alpine/v3.10/community/x86_64/APKINDEX.tar.gz
WARNING: Ignoring http://dl-cdn.alpinelinux.org/alpine/v3.10/community/x86_64/APKINDEX.tar.gz: IO ERROR
ERROR: unsatisfiable constraints:
  bash (missing):
    required by: world[bash]
  build-base (missing):
    required by: world[build-base]
  libffi-dev (missing):
    required by: world[libffi-dev]
  openssl-dev (missing):
    required by: world[openssl-dev]
  pigz (missing):
    required by: world[pigz]
  py-pip (missing):
    required by: world[py-pip]
  python-dev (missing):
    required by: world[python-dev]
```

This PR updates our circleCI configuration to:
- install Alpine packages for python3
- updates the docker image used from 18:09 to 19.03