### PR TITLE
HC-380: accept json content to receive revokes

### DIFF
--- a/cluster/data/celeryconfig.py
+++ b/cluster/data/celeryconfig.py
@@ -3,7 +3,7 @@ CELERY_RESULT_BACKEND = "redis://mozart-redis"
 
 CELERY_TASK_SERIALIZER = "msgpack"
 CELERY_RESULT_SERIALIZER = "msgpack"
-CELERY_ACCEPT_CONTENT = ["msgpack"]
+CELERY_ACCEPT_CONTENT = ["msgpack", "json"]
 CELERY_TIMEZONE = "US/Pacific-New"
 CELERY_ENABLE_UTC = True
 


### PR DESCRIPTION
This PR updates the celeryconfig.py.tmpl template to include json as acceptable content, which is the format of broadcasted revoke payloads.
This was tested in NISAR using the NASA demo pipeline (dev-e2e + ALOS L0B processed to RSLC, GSLC and GCOV).