### PR TITLE
added AWS environment variables to verdi's docker-compose.yml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,6 @@ dmypy.json
 .pyre/
 
 .idea
+
+.dockerhub
+.git_oauth_token

--- a/verdi/docker-compose.yml
+++ b/verdi/docker-compose.yml
@@ -6,6 +6,9 @@ services:
     image: hysds/verdi
     init: true
     user: "${HOST_UID}:${HOST_GID}"
+    environment:
+      - AWS_METADATA_SERVICE_TIMEOUT=5
+      - AWS_METADATA_SERVICE_NUM_ATTEMPTS=5
     ports:
       - "80:80"
       - "443:443"


### PR DESCRIPTION
https://boto3.amazonaws.com/v1/documentation/api/latest/guide/quickstart.html
https://docs.aws.amazon.com/sdkref/latest/guide/feature-ec2-instance-metadata.html

AWS has environment variables related which can help us lower the chances of encountering the `Unable to locate credentials` error
> AWS_METADATA_SERVICE_TIMEOUT
The number of seconds before a connection to the instance metadata service should time out. When attempting to retrieve credentials on an Amazon EC2 instance that is configured with an IAM role, a connection to the instance metadata service will time out after 1 second by default. If you know you’re running on an EC2 instance with an IAM role configured, you can increase this value if needed.

> AWS_METADATA_SERVICE_NUM_ATTEMPTS
When attempting to retrieve credentials on an Amazon EC2 instance that has been configured with an IAM role, Boto3 will make only one attempt to retrieve credentials from the instance metadata service before giving up. If you know your code will be running on an EC2 instance, you can increase this value to make Boto3 retry multiple times before giving up.


change(s):
- added AWS environment variables to verdi's docker-compose.yml
- added creds files to .gitignore

related PR(s) & tickets:
- https://github.com/hysds/osaka/pull/37
- https://github.com/hysds/hysds/pull/162
- https://hysds-core.atlassian.net/browse/HC-458
- https://hysds-core.atlassian.net/browse/HC-461
- https://jira.jpl.nasa.gov/browse/NSDS-2724