### PR TITLE
Enable SSL/TLS for gunicorn for Mozart and GRQ API endpoints

### DIFF
--- a/cluster/data/grq/etc/supervisord.conf
+++ b/cluster/data/grq/etc/supervisord.conf
@@ -35,6 +35,8 @@ startsecs=10
 [program:grq2]
 directory=/home/ops/sciflo/ops/grq2
 command=gunicorn -w4 -b 0.0.0.0:8878 -k gevent --log-level=debug
+        --keyfile=/etc/pki/tls/private/localhost.key
+        --certfile=/etc/pki/tls/certs/localhost.crt
         --limit-request-line=0 grq2:app
 process_name=%(program_name)s
 priority=1

--- a/cluster/data/mozart/etc/supervisord.conf
+++ b/cluster/data/mozart/etc/supervisord.conf
@@ -107,6 +107,8 @@ startsecs=10
 [program:mozart_job_management]
 directory=/home/ops/mozart/ops/mozart
 command=gunicorn -w4 -b 127.0.0.1:8888 -k gevent --timeout=3600
+        --keyfile=/etc/pki/tls/private/localhost.key
+        --certfile=/etc/pki/tls/certs/localhost.crt
         --graceful-timeout=3600 --log-level=debug
         --limit-request-line=0 mozart:app
 process_name=%(program_name)s


### PR DESCRIPTION
Update gunicorn API endpoints for Mozart/GRQ to use system-provided certificate for https